### PR TITLE
Exercise material changes

### DIFF
--- a/documentation/docs/answers/csv2bufr-answers.md
+++ b/documentation/docs/answers/csv2bufr-answers.md
@@ -75,7 +75,7 @@ title: Converting CSV data to BUFR answers
 
     !!! note
         The value returned is not the same exact value as what is present in the CSV file: 54.09.
-        This is because this particular ecCode is always an integer, so is rounded.
+        This is because some variables (such as relative humidity) in BUFR are always integers, hence are rounded.
 
 
 ## Exercise 4
@@ -118,34 +118,30 @@ title: Converting CSV data to BUFR answers
 
 ## Exercise 5
 
-1. Non coordinate pressure (QNH) takes a negative value and the air temperature is too high.
-
-2. This will vary from person to person, but here is an example:
-
-    | Variable        | Minimum | Maximum |
-    |-----------------|---------|---------|
-    | Pressure (Pa)   | 0       | 150000  |
-    | Temperature (C) | -20     | 50      |
-
-3. You should have the following line in your mappings file:
+1. When converting `ex_5.csv` to BUFR, we come across the following error:
 
     ```bash
-    {"eccodes_key": "#1#pressureReducedToMeanSeaLevel", "value":"data:QNH", "valid_min": "const:0", "valid_max": "const:150000"}
+    #1#pressureReducedToMeanSeaLevel: Value (102043.2) out of valid range (50000 - 100000).; Element set to missing
+    #1#airTemperature: Value (25.85) out of valid range (-10 - 25).; Element set to missing
     ```
+
+2. By using the following command:
 
     ```bash
-    {"eccodes_key": "#1#airTemperature", "value":"data:AirTempC", "valid_min": "const:-20", "valid_max": "const:50", "offset": "const:273.15", "scale": "const:0"}
+    bufr_dump -p WIGOS_0-454-2-AWSMULANJE_20230526T005500.bufr4 | egrep -i 'pressureReducedToMeanSeaLevel|airTemperature|dewpointTemperature'
     ```
 
-    !!! note
-    The valid minimum and maximum values should take the same units as the CSV data.
-
-4. You will see the following error:
+    which gives output:
 
     ```bash
-    #1#pressureReducedToMeanSeaLevel: Value (-102043.2) out of valid range (0 - 150000).; Element set to missing
-    #1#airTemperature: Value (2585.0) out of valid range (-20 - 50).; Element set to missing
+    pressureReducedToMeanSeaLevel=MISSING
+    airTemperature=MISSING
+    dewpointTemperature=289.1
     ```
 
-    and a BUFR file will still be written. However, it will not contain the values of these variables, as they are set to missing.
+    We find that the pressure and air temperature variables are missing because, from the error found in part 1, these variables are outside of the valid range.
+
+3. This is personal preference.
+
+4. Provided the values of `QNH`, `AirTempC`, and `DewPointTempC` are within the ranges set in the previous part, the CSV file should convert to BUFR without any errors.
 

--- a/documentation/docs/answers/csv2bufr-answers.md
+++ b/documentation/docs/answers/csv2bufr-answers.md
@@ -39,7 +39,7 @@ title: Converting CSV data to BUFR answers
 
     You should see the following error:
 
-    ```bash
+    ```
     Column RH not found in input data
     ```
 
@@ -49,13 +49,13 @@ title: Converting CSV data to BUFR answers
 
 3. We do this by changing the line:
 
-    ```bash
+    ```
     {"eccodes_key": "#1#relativeHumidity", "value":"data:RH"}
     ```
 
     to:
 
-    ```bash
+    ```
     {"eccodes_key": "#1#relativeHumidity", "value":"data:RelativeHumidity"}
     ```
 
@@ -85,22 +85,22 @@ title: Converting CSV data to BUFR answers
 3. 273.15, as 0 degrees C = 273.15 K
 4. You should have the following line in your mapppings file:
 
-    ```bash
+    ```
     {"eccodes_key": "#1#nonCoordinatePressure", "value":"data:BP", "offset": "const:0", "scale": "const:2"}
     ```
 
 5. You should have the following line in your mappings file:
 
-    ```bash
+    ```
     {"eccodes_key": "#1#airTemperature", "value":"data:AirTempC"}
     {"eccodes_key": "#1#dewpointTemperature", "value":"data:DewPointTempC"}
     ```
 
-6. ```bash
+6. ```
     {"eccodes_key": "#1#airTemperature", "value":"data:AirTempC", "offset": "const:273.15", "scale": "const:0"}
     ```
 
-7. ```bash
+7. ```
     {"eccodes_key": "#1#dewpointTemperature", "value":"data:DewPointTempC", "offset": "const:273.15", "scale": "const:0"}
     ```
 
@@ -118,7 +118,7 @@ title: Converting CSV data to BUFR answers
 
 ## Exercise 5
 
-1. When converting `ex_5.csv` to BUFR, we come across the following error:
+1. When converting `ex_5.csv` to BUFR, we see the following error:
 
     ```bash
     #1#pressureReducedToMeanSeaLevel: Value (102043.2) out of valid range (50000 - 100000).; Element set to missing
@@ -131,9 +131,9 @@ title: Converting CSV data to BUFR answers
     bufr_dump -p WIGOS_0-454-2-AWSMULANJE_20230526T005500.bufr4 | egrep -i 'pressureReducedToMeanSeaLevel|airTemperature|dewpointTemperature'
     ```
 
-    which gives output:
+    which gives the following output:
 
-    ```bash
+    ```
     pressureReducedToMeanSeaLevel=MISSING
     airTemperature=MISSING
     dewpointTemperature=289.1
@@ -144,4 +144,3 @@ title: Converting CSV data to BUFR answers
 3. This is personal preference.
 
 4. Provided the values of `QNH`, `AirTempC`, and `DewPointTempC` are within the ranges set in the previous part, the CSV file should convert to BUFR without any errors.
-

--- a/documentation/docs/answers/synop2bufr-answers.md
+++ b/documentation/docs/answers/synop2bufr-answers.md
@@ -17,7 +17,7 @@ title: Converting SYNOP data to BUFR answers
 1. This can be done using the following command:
 
     ```bash
-    bufr_dump -p WIGOS_0-20000-0-15015_20230221T120000.bufr4 | egrep -i 'latitude|longitude'
+    bufr_dump -p <file.bufr4> | egrep -i 'latitude|longitude'
     ```
 
 ## Exercise 2
@@ -34,15 +34,15 @@ title: Converting SYNOP data to BUFR answers
 1. This can be done using the following commands:
 
     ```bash
-    bufr_dump -p WIGOS_0-20000-0-15015_20230221T120000.bufr4 | egrep -i 'wigos'
+    bufr_dump -p <file.bufr4> | egrep -i 'wigos'
     ```
 
     ```bash
-    bufr_dump -p WIGOS_0-20000-0-15020_20230221T120000.bufr4 | egrep -i 'wigos'
+    bufr_dump -p <file.bufr4> | egrep -i 'wigos'
     ```
 
     ```bash
-    bufr_dump -p WIGOS_0-20000-0-15090_20230221T120000.bufr4 | egrep -i 'wigos'
+    bufr_dump -p <file.bufr4> | egrep -i 'wigos'
     ```
 
     Note that if you have a directory with just these 3 BUFR files, you can use Linux wildcards as follows:
@@ -63,7 +63,7 @@ title: Converting SYNOP data to BUFR answers
 1. This can be done in one command:
 
     ```bash
-    bufr_dump -p WIGOS_0-20000-0-15260_20230221T115500.bufr4 | egrep -i 'temperature|cover|sunshine|wind'
+    bufr_dump -p <file.bufr4> | egrep -i 'temperature|cover|sunshine|wind'
     ```
 
 Of course a command for each variable can also be used.

--- a/documentation/docs/practical-sessions/converting-csv-data-to-bufr.md
+++ b/documentation/docs/practical-sessions/converting-csv-data-to-bufr.md
@@ -29,6 +29,24 @@ ls
 
 ## csv2bufr primer
 
+### Necessary CSV data
+
+There are some requirements on the data that must be present in the CSV file:
+
+- WIGOS Station Identifier, either in 1 column or split over 4 columns for each component
+- Observation year
+- Observation month
+- Observation day
+- Observation hour
+- Observation minute
+- Latitude
+- Longitude
+- Station height
+- Barometer height
+
+!!! note
+    Notice that the datetime of the observation is split into 5 different columns.
+
 Below are essential `csv2bufr` commands and configurations:
 
 ### mappings Create
@@ -120,7 +138,7 @@ and open the CSV data `ex_2.csv`.
 
 Now open the mappings file `mappings_2.json`. By looking at the eccodes keys related to dates and times, it should seem clear that it is not possible to map the datetime with the CSV in its current state.
 
-2. Create new columns in the CSV file for each component of the datetime, with appropriate column names to match those of the mapping file.
+2. Create new columns in the CSV file for each component of the datetime: `Year`, `Month`, `Day`, `Hour`, `Minute`.
 
 3. By the `data transform` command, use the mappings file to convert this CSV data to BUFR.
 
@@ -196,7 +214,7 @@ Open the mappings file `mappings_4.json`. Find the lines corresponding to the va
 9. Use the `bufr_dump` command to verify that `nonCoordinatePressure`, `airTemperature` and `dewpointTemperature` have the values you would expect after conversion.
 
 ### Exercise 5: Implementing quality control
-In this exercise, we will implement some minimum and maximum tolerable values to prevent clearly incorrect data from being converted to BUFR. To do this, we will use `valid_min` and `valid_max` in the mappings file.
+In this exercise, we will implement some minimum and maximum tolerable values to prevent data of certain varaibles from being encoded into BUFR. To do this, we will use `valid_min` and `valid_max` in the mappings file.
 
 Navigate to the `ex_5` directory:
 
@@ -204,22 +222,24 @@ Navigate to the `ex_5` directory:
 cd ~/exercise-materials/csv2bufr-exercises/ex_5
 ```
 
-and open the CSV data `ex_5.csv`.
+1. By the `data transform` command, use the mappings file to convert this CSV data to BUFR. What error occurs? Is a BUFR file created?
 
-1. Which two variables have values that are clearly incorrect?
-2. For each of these variables, decide on some sensible minimum and maximum tolerable values.
+2. Use the `bufr_dump` command to check the values of `pressureReducedToMeanSeaLevel`, `airTemperature` and `dewpointTemperature`. Which variables are missing, and why?
 
-Open the mappings file `mappings_5.json`. Find the lines corresponding to the variables above.
+Open the mappings file `mappings_5.json`. Find the lines corresponding to the variables above. You will find the following on these lines:
 
-3. Implement these minimum and maximum values by adding the following line to the right of the `data:` code:
+```bash
+"valid_min": "const:a", "valid_max": "const:b"
+```
 
-    ```bash
-    "valid_min": "const:a", "valid_max": "const:b"
-    ```
-    
-    where a and b are values you chose in part 2.
+where `a` and `b` are values. These values represent the minimum and maximum tolerable extremes for encoding into BUFR. 
 
-4. By the `data transform` command, use this mappings file to convert this CSV data to BUFR. What happens? Is a BUFR file written?
+3. Change `a` and `b` on each line to form a less tight range of tolerance for these variables.
+
+    !!! note
+    The valid minimum and maximum values should take the same units as the CSV data.
+
+4. By the `data transform` command, use this mappings file to convert this CSV data to BUFR again. Do you notice an errors this time?
 
 ## Conclusion
 
@@ -228,5 +248,7 @@ Open the mappings file `mappings_5.json`. Find the lines corresponding to the va
     In this practical session, you learned:
 
     - The basic usage of `csv2bufr`
+    - The required structure of CSV data for conversion to BUFR
     - How to update a simple csv2bufr mapping file for a variety of scenarios, including for GBON requirements, unit conversion, and quality control/range checking
-    - How to `csv2bufr` on a test data file and convert to BUFR format
+    - How to use `csv2bufr` on a test data file and convert to BUFR format
+    - How to use `bufr_dump` to verify the values of BUFR encoded variables

--- a/documentation/docs/practical-sessions/converting-csv-data-to-bufr.md
+++ b/documentation/docs/practical-sessions/converting-csv-data-to-bufr.md
@@ -239,7 +239,7 @@ where `a` and `b` are values. These values represent the minimum and maximum tol
     !!! note
     The valid minimum and maximum values should take the same units as the CSV data.
 
-4. By the `data transform` command, use this mappings file to convert this CSV data to BUFR again. Do you notice an errors this time?
+4. By the `data transform` command, use this mappings file to convert this CSV data to BUFR again. Do you notice any errors this time?
 
 ## Conclusion
 

--- a/documentation/docs/practical-sessions/converting-csv-data-to-bufr.md
+++ b/documentation/docs/practical-sessions/converting-csv-data-to-bufr.md
@@ -33,7 +33,7 @@ ls
 
 There are some requirements on the data that must be present in the CSV file:
 
-- WIGOS Station Identifier, either in 1 column or split over 4 columns for each component
+- WIGOS Station Identifier, either in 1 column or split over 4 columns for each component as follows:
 - Observation year
 - Observation month
 - Observation day
@@ -45,7 +45,7 @@ There are some requirements on the data that must be present in the CSV file:
 - Barometer height
 
 !!! note
-    Notice that the datetime of the observation is split into 5 different columns.
+    Notice that the datetime of the observation is split into 5 different columns (from most to least significant).
 
 Below are essential `csv2bufr` commands and configurations:
 
@@ -209,12 +209,12 @@ Open the mappings file `mappings_4.json`. Find the lines corresponding to the va
 
     where `y` is your answer in part 4.
 
-8. By the `data transform` command, use the mappings file to convert this CSV data to BUFR.
+8. By running the `csv2bufr data transform` command, use the mappings file to convert this CSV data to BUFR.
 
 9. Use the `bufr_dump` command to verify that `nonCoordinatePressure`, `airTemperature` and `dewpointTemperature` have the values you would expect after conversion.
 
 ### Exercise 5: Implementing quality control
-In this exercise, we will implement some minimum and maximum tolerable values to prevent data of certain varaibles from being encoded into BUFR. To do this, we will use `valid_min` and `valid_max` in the mappings file.
+In this exercise, we will implement some minimum and maximum tolerable values to prevent data of certain variables from being encoded into BUFR. To do this, we will use `valid_min` and `valid_max` in the mappings file.
 
 Navigate to the `ex_5` directory:
 
@@ -222,7 +222,7 @@ Navigate to the `ex_5` directory:
 cd ~/exercise-materials/csv2bufr-exercises/ex_5
 ```
 
-1. By the `data transform` command, use the mappings file to convert this CSV data to BUFR. What error occurs? Is a BUFR file created?
+1. By running the `csv2bufr data transform` command, use the mappings file to convert this CSV data to BUFR. What error occurs? Is a BUFR file created?
 
 2. Use the `bufr_dump` command to check the values of `pressureReducedToMeanSeaLevel`, `airTemperature` and `dewpointTemperature`. Which variables are missing, and why?
 
@@ -239,7 +239,7 @@ where `a` and `b` are values. These values represent the minimum and maximum tol
     !!! note
     The valid minimum and maximum values should take the same units as the CSV data.
 
-4. By the `data transform` command, use this mappings file to convert this CSV data to BUFR again. Do you notice any errors this time?
+4. By running the `csv2bufr data transform` command, use this mappings file to convert this CSV data to BUFR again. Do you notice any errors this time?
 
 ## Conclusion
 

--- a/documentation/docs/practical-sessions/converting-synop-data-to-bufr.md
+++ b/documentation/docs/practical-sessions/converting-synop-data-to-bufr.md
@@ -50,7 +50,7 @@ Note that if the metadata, output directory, year and month options are not spec
 | --month | The current month. |
 
 !!! note
-    One must be cautious using the default year and month, as the day of the month specified in the report may not correspond with this. E.g. June 2023 does not have a 31st day.
+    One must be cautious using the default year and month, as the day of the month specified in the report may not correspond (e.g. June does not have 31 days).
 
 In the examples, the year and month are not given, so feel free to specify a date yourself or use the default values.
 

--- a/documentation/docs/practical-sessions/converting-synop-data-to-bufr.md
+++ b/documentation/docs/practical-sessions/converting-synop-data-to-bufr.md
@@ -49,6 +49,9 @@ Note that if the metadata, output directory, year and month options are not spec
 | --year | The current year. |
 | --month | The current month. |
 
+!!! note
+    One must be cautious using the default year and month, as the day of the month specified in the report may not correspond with this. E.g. June 2023 does not have a 31st day.
+
 In the examples, the year and month are not given, so feel free to specify a date yourself or use the default values.
 
 ## ecCodes primer

--- a/exercise-materials/csv2bufr-exercises/answers/ex_5/ex_5.csv
+++ b/exercise-materials/csv2bufr-exercises/answers/ex_5/ex_5.csv
@@ -2,4 +2,4 @@ CR300,14306,CR310-CELL215.Std.10.04,CPU:CR310_Malawi_Mulanje_V1R9_19012022_T3.CR
 WMO_Block,Station_ID,Station_Name,WMO_Station_Type,M_Year,M_Month,M_DayOfMonth,M_HourOfDay,M_Minutes,Latitude,Longitude,Elevation,BP_Elevation,BP,QNH,BP_Change,BP_Tendency,Temp_H,AirTempC,DewPointTempC,RelativeHumidity
 ,,,,,,,,,,,,m,hPa,Pa,Pa,,m,C,C,%
 Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp
-6,0-454-2-AWSMULANJE,Mulanje,0,2023,5,26,0,55,-16.03,35.51,649,650,944.1767,102043.2,-35.4375,7,1.5,2585,15.95,54.09
+6,0-454-2-AWSMULANJE,Mulanje,0,2023,5,26,0,55,-16.03,35.51,649,650,944.1767,102043.2,-35.4375,7,1.5,25.85,15.95,54.09

--- a/exercise-materials/csv2bufr-exercises/answers/ex_5/ex_5.csv
+++ b/exercise-materials/csv2bufr-exercises/answers/ex_5/ex_5.csv
@@ -2,4 +2,4 @@ CR300,14306,CR310-CELL215.Std.10.04,CPU:CR310_Malawi_Mulanje_V1R9_19012022_T3.CR
 WMO_Block,Station_ID,Station_Name,WMO_Station_Type,M_Year,M_Month,M_DayOfMonth,M_HourOfDay,M_Minutes,Latitude,Longitude,Elevation,BP_Elevation,BP,QNH,BP_Change,BP_Tendency,Temp_H,AirTempC,DewPointTempC,RelativeHumidity
 ,,,,,,,,,,,,m,hPa,Pa,Pa,,m,C,C,%
 Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp
-6,0-454-2-AWSMULANJE,Mulanje,0,2023,5,26,0,55,-16.03,35.51,649,650,944.1767,-102043.2,-35.4375,7,1.5,2585,15.95,54.09
+6,0-454-2-AWSMULANJE,Mulanje,0,2023,5,26,0,55,-16.03,35.51,649,650,944.1767,102043.2,-35.4375,7,1.5,2585,15.95,54.09

--- a/exercise-materials/csv2bufr-exercises/answers/ex_5/mappings_5.json
+++ b/exercise-materials/csv2bufr-exercises/answers/ex_5/mappings_5.json
@@ -47,8 +47,8 @@
         {"eccodes_key": "#1#3HourPressureChange",                                  "value":"data:BP_Change", "valid_min": "const:-5000", "valid_max": "const:5230"},
         {"eccodes_key": "#1#characteristicOfPressureTendency",                     "value":"data:BP_Tendency"},
         {"eccodes_key": "#1#heightOfSensorAboveLocalGroundOrDeckOfMarinePlatform", "value":"data:Temp_H"},
-        {"eccodes_key": "#1#airTemperature",                                       "value":"data:AirTempC", "valid_min": "const:-20", "valid_max": "const:50", "offset": "const:273.15", "scale": "const:0"},
-        {"eccodes_key": "#1#dewpointTemperature",                                  "value":"data:DewPointTempC", "offset": "const:273.15", "scale": "const:0"},
+        {"eccodes_key": "#1#airTemperature",                                       "value":"data:AirTempC", "valid_min": "const:-30", "valid_max": "const:50", "offset": "const:273.15", "scale": "const:0"},
+        {"eccodes_key": "#1#dewpointTemperature",                                  "value":"data:DewPointTempC", "valid_min": "const:-30", "valid_max": "const:50", "offset": "const:273.15", "scale": "const:0"},
         {"eccodes_key": "#1#relativeHumidity",                                     "value":"data:RelativeHumidity"}
     ]
 }

--- a/exercise-materials/csv2bufr-exercises/ex_2/mappings_2.json
+++ b/exercise-materials/csv2bufr-exercises/ex_2/mappings_2.json
@@ -19,11 +19,11 @@
         {"eccodes_key": "numberOfSubsets", "value": "const:1"},
         {"eccodes_key": "observedData", "value": "const:1"},
         {"eccodes_key": "compressedData", "value": "const:0"},
-        {"eccodes_key": "typicalYear", "value":"data:M_Year"},
-        {"eccodes_key": "typicalMonth", "value":"data:M_Month"},
-        {"eccodes_key": "typicalDay", "value":"data:M_DayOfMonth"},
-        {"eccodes_key": "typicalHour", "value":"data:M_HourOfDay"},
-        {"eccodes_key": "typicalMinute", "value":"data:M_Minutes"},
+        {"eccodes_key": "typicalYear", "value":"data:Year"},
+        {"eccodes_key": "typicalMonth", "value":"data:Month"},
+        {"eccodes_key": "typicalDay", "value":"data:Day"},
+        {"eccodes_key": "typicalHour", "value":"data:Hour"},
+        {"eccodes_key": "typicalMinute", "value":"data:Minute"},
         {"eccodes_key": "unexpandedDescriptors", "value": "array:301150,307080"}
     ],
     "data": [

--- a/exercise-materials/csv2bufr-exercises/ex_5/ex_5.csv
+++ b/exercise-materials/csv2bufr-exercises/ex_5/ex_5.csv
@@ -2,4 +2,4 @@ CR300,14306,CR310-CELL215.Std.10.04,CPU:CR310_Malawi_Mulanje_V1R9_19012022_T3.CR
 WMO_Block,Station_ID,Station_Name,WMO_Station_Type,M_Year,M_Month,M_DayOfMonth,M_HourOfDay,M_Minutes,Latitude,Longitude,Elevation,BP_Elevation,BP,QNH,BP_Change,BP_Tendency,Temp_H,AirTempC,DewPointTempC,RelativeHumidity
 ,,,,,,,,,,,,m,hPa,Pa,Pa,,m,C,C,%
 Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp,Smp
-6,0-454-2-AWSMULANJE,Mulanje,0,2023,5,26,0,55,-16.03,35.51,649,650,944.1767,-102043.2,-35.4375,7,1.5,2585,15.95,54.09
+6,0-454-2-AWSMULANJE,Mulanje,0,2023,5,26,0,55,-16.03,35.51,649,650,944.1767,102043.2,-35.4375,7,1.5,25.85,15.95,54.09

--- a/exercise-materials/csv2bufr-exercises/ex_5/mappings_5.json
+++ b/exercise-materials/csv2bufr-exercises/ex_5/mappings_5.json
@@ -43,12 +43,12 @@
         {"eccodes_key": "#1#heightOfStationGroundAboveMeanSeaLevel",               "value":"data:Elevation"},
         {"eccodes_key": "#1#heightOfBarometerAboveMeanSeaLevel",                   "value":"data:BP_Elevation"},
         {"eccodes_key": "#1#nonCoordinatePressure",                                "value":"data:BP", "offset": "const:0", "scale": "const:2"},
-        {"eccodes_key": "#1#pressureReducedToMeanSeaLevel",                        "value":"data:QNH"},
+        {"eccodes_key": "#1#pressureReducedToMeanSeaLevel",                        "value":"data:QNH", "valid_min": "const:50000", "valid_max": "100000"},
         {"eccodes_key": "#1#3HourPressureChange",                                  "value":"data:BP_Change", "valid_min": "const:-5000", "valid_max": "const:5230"},
         {"eccodes_key": "#1#characteristicOfPressureTendency",                     "value":"data:BP_Tendency"},
         {"eccodes_key": "#1#heightOfSensorAboveLocalGroundOrDeckOfMarinePlatform", "value":"data:Temp_H"},
-        {"eccodes_key": "#1#airTemperature",                                       "value":"data:AirTempC", "offset": "const:273.15", "scale": "const:0"},
-        {"eccodes_key": "#1#dewpointTemperature",                                  "value":"data:DewPointTempC", "offset": "const:273.15", "scale": "const:0"},
+        {"eccodes_key": "#1#airTemperature",                                       "value":"data:AirTempC", "valid_min": "const:-10", "valid_max": "const:25", "offset": "const:273.15", "scale": "const:0"},
+        {"eccodes_key": "#1#dewpointTemperature",                                  "value":"data:DewPointTempC", "valid_min": "const:-10", "valid_max": "const:25", "offset": "const:273.15", "scale": "const:0"},
         {"eccodes_key": "#1#relativeHumidity",                                     "value":"data:RelativeHumidity"}
     ]
 }


### PR DESCRIPTION
I have made the following changes:

## synop2bufr
- In the preparation section, I warn the user that the use of default values for `--year` and `--month` may be problematic if the day of the month in the synop report is not compatible, e.g. June 31st or Feb 30th.
- Answers have been changed to include generic BUFR filenames `<file.bufr4>` rather than the actual name of the BUFR file, because this is dependent on the value of `--year` and `--month`.
## csv2bufr
- In the preparation section, I inform the user of the columns necessary to be present for use with csv2bufr.
- Ex.2 now specifically tells the user what columns to make, and the mapping file reflects this.
- Ex.5 has been remade to include a pre-existing overly tight quality control range for mean sea level pressure and temperature, in which the user must investigate the error that occurs when converting to BUFR and adjust the quality control range in the mapping file to fix this.