### PR TITLE
improve exercise-materials for ConvertingCSV data to BUFR

### DIFF
--- a/documentation/docs/practical-sessions/converting-csv-data-to-bufr.en.md
+++ b/documentation/docs/practical-sessions/converting-csv-data-to-bufr.en.md
@@ -181,7 +181,7 @@ The use of this form is intended for debugging and validation purposes, the reco
 
 Navigate to CSV Form on the the wis2box web-application 
 (``http://<your-host-name>/wis2box-webapp/csv2bufr_form``).
-Click the entry box or drag and drop the test file you have downloaded to the entry box. 
+Use the file [aws-example.csv](/sample-data/aws-example.csv) for this exercise.
 You should now be able to click next to preview and validate the file.
 
 <center><img alt="Image showing CSV to BUFR upload screen" src="../../assets/img/csv2bufr-ex1.png"/></center>


### PR DESCRIPTION
The updated training page would be like:
<img width="998" alt="Screenshot 2025-03-11 at 14 34 42" src="https://github.com/user-attachments/assets/28a98772-bf06-46c2-a3a6-4a299817cff4" />

Testing exercise-materials:
<img width="255" alt="image" src="https://github.com/user-attachments/assets/0e469a29-c608-435a-8cdf-34d71c7eafc1" />
The default "AWS-template.csv" will have an error:
<img width="945" alt="image" src="https://github.com/user-attachments/assets/74ba97d2-339f-4d4c-a53a-6e3f656a4d93" />
When I changed the value it runs well:
<img width="986" alt="image" src="https://github.com/user-attachments/assets/4615b602-d411-4000-b757-440a6fb59340" />
<img width="985" alt="image" src="https://github.com/user-attachments/assets/63f18166-b9c7-4c56-b751-14e53aca9f4e" />
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/6b0ab0b3-53be-4f6d-bf42-dd52eaff3c77" />

