### PR TITLE
pin MkDocs to 1.x

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs
+mkdocs<2
 mkdocs-material
 mkdocs-table-reader-plugin
 mkdocs-static-i18n


### PR DESCRIPTION
This PR pins MkDocs to 1.x, given (https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/).

We will need to update to Zensical in a future PR.